### PR TITLE
商品詳細ページ金額表示機能修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -23,7 +23,7 @@
           = image_tag i.image.url ,class: "images"
         %p.box-item-name-price 
           %span.price_tag>
-            = number_to_currency(@item.price, unit: "￥",precision: 0)e
+            = number_to_currency(@item.price, unit: "￥",precision: 0)
           %table.box-item-name-price-2
             %tr 
             %th 商品名


### PR DESCRIPTION
# what
コンフリクト解消時に余分な文字が
入ってしまったので修正

# why
金額に￥マーク、カンマを表示させる為