### PR TITLE
出品ページのヘッダーロゴにlinkを繋げる

### DIFF
--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,5 +1,6 @@
 .exhibitionHeader
-  = image_tag "logo.png", alt: "furima icon", id: "pic1", class: "exhibitionHeader__logo"
+  = link_to root_path do
+    = image_tag "logo.png", alt: "furima icon", id: "pic1", class: "exhibitionHeader__logo"
 .main
   .main__exhibitionContents
     = form_with model: @item, local: true do |f|


### PR DESCRIPTION
# what
itemの出品ページのヘッダーロゴにlink_toを設置

# why
出品ページのロゴにトップページへのリンクを繋げる