### PR TITLE
未ログインユーザーの閲覧制限実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,8 +10,12 @@ class ItemsController < ApplicationController
 
 
   def new
-    @item = Item.new
-    @item.images.new
+    if user_signed_in?
+      @item = Item.new
+      @item.images.new
+    else
+      redirect_to new_user_registration_path
+    end
   end
 
   def create

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,21 +66,22 @@
             %th 発送日の目安
             %td
               = @item.shipping_date_id
-      %p.box-item-name-price-3
-        %a.submit-4 
-        - if @item.buyer_id.present? && @item.seller_id.present?
-          .soldOut
-            SOLD OUT
-        - elsif current_user.id != @item.seller_id
-          = link_to '商品購入画面', buyer_path(@item.id), method: :get, class:"submit-4"
-        - else
-          %a.submit-6 
-            = link_to "削除", item_path(@item.id), method: :delete ,class:"submit-6"
-          %a.submit-5
-            = link_to '商品編集', "#{@item.id}/edit", class:"submit-5"
-            %p.box-item-name-price-comment
-              %a.previous-page ＜ 前の商品
-              %a.next-page 次の商品 ＞
-            %p.box-item-name-price-list
-              %a.list_link 商品一覧へ
+      - if user_signed_in?
+        %p.box-item-name-price-3
+          %a.submit-4 
+          - if @item.buyer_id.present? && @item.seller_id.present?
+            .soldOut
+              SOLD OUT
+          - elsif current_user.id != @item.seller_id
+            = link_to '商品購入画面', buyer_path(@item.id), method: :get, class:"submit-4"
+          - else
+            %a.submit-6 
+              = link_to "削除", item_path(@item.id), method: :delete ,class:"submit-6"
+            %a.submit-5
+              = link_to '商品編集', "#{@item.id}/edit", class:"submit-5"
+      - else
+        %a.submit-5
+          = link_to "新規会員登録", new_user_registration_path
+      %p.box-item-name-price-list
+        %a.list_link 商品一覧へ
   = render 'toppages/toppage_footer'


### PR DESCRIPTION
# what
## 未ログイン時はトップページと商品詳細ページのみ閲覧可能
- itemコントローラーのnewアクションにuser_signed_in?の記述を追加し
ログイン時のみ投稿可能に、未ログイン時は新規投稿ページへリンクを飛ばす
- 未ログインユーザーは商品詳細画面のみ閲覧可能購入ボタンは選択不可
未ログインユーザーはトップページと
アイテム詳細画面のみ確認可能
それ以外はユーザー新規登録画面へ遷移

# why
未ログイン時の動作を制限するため