### PR TITLE
出品ページ　画像投稿機能にエラーハンドリング追記

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,6 +19,7 @@ class Item < ApplicationRecord
   validates :region_id, presence: true
   validates :shipping_date_id, presence: true
   validates :price, presence: true
+  validates :images, presence: true
 
 
   


### PR DESCRIPTION
# what
モデルitem.rbにimageに関する
バリデーションを追記

# why
画像がない状態の場合に出品不可にするため