### PR TITLE
商品編集ページ　updateアクション　エラーハンドリング

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -67,10 +67,14 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-    if @item.update(item_params)
-       redirect_to item_path
+    if user_signed_in? && @item.seller_id == current_user.id
+      if @item.update(item_params)
+        redirect_to item_path
+      else
+        redirect_to edit_item_path
+      end
     else
-       render action: :edit
+      redirect_to root_path 
     end
   end
 


### PR DESCRIPTION
# what
itemコントローラーのupdateアクションに
エラーハンドリングの為の記述を追加

# why
updateアクションにエラーハンドリング追加
ログイン中かつ自分が出品した商品のみを更新できる様に実装
悪因のあるユーザーがedit Actionをすり抜けupdateを出来ない様に