### PR TITLE
商品購入機能　修正

### DIFF
--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -20,7 +20,7 @@ class BuyersController < ApplicationController
 
   def pay
     redirect_to root_path if @item.seller_id == current_user.id || @item.buyer_id != nil
-      Item.update(buyer_id: current_user.id)
+      @item.update(buyer_id: current_user.id)
       Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       Payjp::Charge.create(
         :amount => @item.price,
@@ -32,7 +32,6 @@ class BuyersController < ApplicationController
 
   def index
     @item = Item.all.where(buyer_id: current_user.id)
-    @user = current_user.nick_name
   end
 
   def edit


### PR DESCRIPTION
# what
商品を購入すると
itemテーブルの全てのレコードのbuyer_idに
購入者のidが入ってしまていたので修正

# why
商品購入機能を正常に稼働させる為に